### PR TITLE
Fix custom event component props

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -670,7 +670,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
   const customGutterHeader = (date: Date) => moment(date).format('HH:mm');
 
   // Custom event component with category emoji
-  const CustomEventComponent = ({ event }: { event: CalendarEvent }) => {
+  const CustomEventComponent = ({ event, ...props }: { event: CalendarEvent } & React.HTMLAttributes<HTMLDivElement>) => {
           let categoryEmoji = '';
       let statusIndicator = '';
       let duration = '';


### PR DESCRIPTION
Fix `ReferenceError: props is not defined` in `CustomEventComponent` by correctly accepting and spreading all component props.

The `CustomEventComponent` was throwing a `ReferenceError` because it attempted to spread `props` in its JSX (`{...props}`) but `props` was not defined in its function parameters. This component is used by `react-big-calendar`, which passes additional HTML attributes and internal props that need to be spread. The fix updates the function signature to properly accept and type these additional props.

---
<a href="https://cursor.com/background-agent?bcId=bc-67dbe6d8-3bcd-4439-85f5-1ec12819dc2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67dbe6d8-3bcd-4439-85f5-1ec12819dc2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>