### PR TITLE
Fix calendar not reflecting new start time

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -63,10 +63,7 @@ const Dashboard: React.FC<DashboardProps> = ({
     }
   };
 
-  // Get sessions with applied time edits
-  const getEditedStudyPlans = () => {
-    return sessionTimeEditor.applyEditsToPlans(studyPlans);
-  };
+  // Note: studyPlans now already includes applied time edits from parent component
 
   // Helper to get start/end of week/month
   const todayDate = new Date();
@@ -126,8 +123,7 @@ const Dashboard: React.FC<DashboardProps> = ({
 
   // Today's plan and workday status for filtered period
   const today = getLocalDateString();
-  const editedPlans = getEditedStudyPlans();
-  const filteredEditedPlans = editedPlans.filter(plan => {
+      const filteredEditedPlans = studyPlans.filter(plan => {
     const planFiltered = filteredPlans.find(fp => fp.date === plan.date);
     return planFiltered !== undefined;
   });

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -54,10 +54,7 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
     setTimeout(() => setNotificationMessage(null), 3000);
   };
 
-  // Get sessions with applied time edits
-  const getEditedStudyPlans = () => {
-    return sessionTimeEditor.applyEditsToPlans(studyPlans);
-  };
+  // Note: studyPlans now already includes applied time edits from parent component
 
   // Resched UI state
   const [reschedModal, setReschedModal] = useState<{ open: boolean; task: any | null }>({ open: false, task: null });
@@ -123,9 +120,8 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
     todayLength: today.length,
     todayParts: today.split('-')
   });
-  const editedStudyPlans = getEditedStudyPlans();
-  const todaysPlan = editedStudyPlans.find(plan => plan.date === today);
-  console.log('today:', today, 'studyPlans:', editedStudyPlans.map(p => p.date));
+  const todaysPlan = studyPlans.find(plan => plan.date === today);
+  console.log('today:', today, 'studyPlans:', studyPlans.map(p => p.date));
   console.log('todaysPlan found:', !!todaysPlan);
   if (todaysPlan) {
     console.log('todaysPlan sessions:', todaysPlan.plannedTasks.map(s => ({
@@ -138,7 +134,7 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
       originalDate: s.originalDate
     })));
   }
-  const upcomingPlans = editedStudyPlans.filter(plan => plan.date > today).slice(0, 7);
+  const upcomingPlans = studyPlans.filter(plan => plan.date > today).slice(0, 7);
   const suggestions = generateSmartSuggestions(tasks);
 
 
@@ -221,7 +217,7 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
   const missedSessions: Array<{planDate: string, session: StudySession, task: Task}> = [];
   
   // Only include past plans (not today's plan)
-  const plansToCheck = editedStudyPlans.filter(plan => plan.date < today);
+      const plansToCheck = studyPlans.filter(plan => plan.date < today);
   
   plansToCheck.forEach(plan => {
     plan.plannedTasks.forEach(session => {
@@ -242,7 +238,7 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
 
   // Debug logging
   console.log('Today:', today);
-  console.log('All study plans:', editedStudyPlans.map(p => ({ date: p.date, tasks: p.plannedTasks.length })));
+  console.log('All study plans:', studyPlans.map(p => ({ date: p.date, tasks: p.plannedTasks.length })));
   console.log('Plans to check (past + today):', plansToCheck.map(p => p.date));
   console.log('Plans to check count:', plansToCheck.length);
   console.log('Missed sessions found:', missedSessions.length);

--- a/src/utils/session-time-editor.ts
+++ b/src/utils/session-time-editor.ts
@@ -25,6 +25,36 @@ export class SessionTimeEditor {
   }
 
   /**
+   * Update the study plans data
+   */
+  updateStudyPlans(studyPlans: StudyPlan[]): void {
+    this.studyPlans = studyPlans;
+  }
+
+  /**
+   * Update the fixed commitments data
+   */
+  updateFixedCommitments(fixedCommitments: FixedCommitment[]): void {
+    this.fixedCommitments = fixedCommitments;
+  }
+
+  /**
+   * Update the settings data
+   */
+  updateSettings(settings: UserSettings): void {
+    this.settings = settings;
+  }
+
+  /**
+   * Update all data at once
+   */
+  updateData(studyPlans: StudyPlan[], fixedCommitments: FixedCommitment[], settings: UserSettings): void {
+    this.studyPlans = studyPlans;
+    this.fixedCommitments = fixedCommitments;
+    this.settings = settings;
+  }
+
+  /**
    * Check if a new start time conflicts with existing sessions or commitments
    */
   checkTimeConflict(


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure calendar and other views reflect edited session start times by synchronizing `SessionTimeEditor` and triggering UI updates.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `SessionTimeEditor` was initialized once and never updated, causing it to use stale data for conflict checking and for applying edits. Additionally, the calendar and other views were not explicitly re-rendering when session time edits were saved. This PR introduces methods to update the `SessionTimeEditor`'s internal state and a mechanism (`sessionTimeEditsRefresh` state) to force re-renders in dependent components, ensuring all views display the correct, edited session times.

---
<a href="https://cursor.com/background-agent?bcId=bc-abe1b74f-6af0-4059-a31e-5a57e03cd315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-abe1b74f-6af0-4059-a31e-5a57e03cd315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>